### PR TITLE
[INT-40] 퀴즈 프리셋 정답 목록 제공 API 추가

### DIFF
--- a/src/controllers/quiz.controllers.ts
+++ b/src/controllers/quiz.controllers.ts
@@ -33,6 +33,22 @@ class QuizController {
 
     return res.status(200).json({ ...presetData, quizList });
   }
+    /**
+   * 특정 프리셋 PIN 넘버에 맞는 데이터를 반환하는 함수 getQuizPreset
+   */
+    static async getQuizAnswerList(req: Request, res: Response) {
+      const { presetPin } = req.query;
+  
+      if (!presetPin)
+        throw new BadRequestError('요청에 담긴 프리셋 PIN 이 없습니다.');
+  
+      if (typeof presetPin !== 'string')
+        throw new BadRequestError('유효하지 않은 프리셋 PIN 번호입니다.');
+  
+      const answerList = await ModelQuiz.getQuizListInPreset(presetPin);
+  
+      return res.status(200).json({ ...answerList });
+    }
   /**
    * 페이지네이션을 기반으로 프리셋 목록을 전달하는 함수 getQuizPresetList
    */

--- a/src/routes/quiz.router.ts
+++ b/src/routes/quiz.router.ts
@@ -8,6 +8,7 @@ const quizRouter = express.Router();
 
 quizRouter.get('/', errorCatchHandler(QuizController.getQuizPreset));
 quizRouter.get('/list', errorCatchHandler(QuizController.getQuizPresetList));
+quizRouter.get('/answer', errorCatchHandler(QuizController.getQuizAnswerList));
 
 quizRouter.delete(
   '/remove',


### PR DESCRIPTION
## Jira Issue 번호
#40

## 작업 내용
- 특정 프리셋에 포함된 퀴즈 이미지와 정답을 담은 배열을 반환하는 API를 추가했습니다.
- `/quiz/answer` API 엔드포인트를 신설하고, query Param 에 담긴 PIN 넘버를 기반으로 정답 목록을 반환하도록 하였습니다.

## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
