### PR TITLE
[INT-48] 퀴즈 힌트 속성 추가 및 PIN 시스템 개선

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,7 @@ REPOSITORY=/home/ubuntu/server-build
 cd $REPOSITORY
 
 sudo rm -rf node_modules
+sudo yarn add --arch=x64 --platform=linux sharp
 sudo yarn install
 
 sudo pm2 reload server

--- a/src/controllers/quiz.controllers.ts
+++ b/src/controllers/quiz.controllers.ts
@@ -37,7 +37,7 @@ class QuizController {
     return res.status(200).json({ ...presetData, quizList, hashtagList });
   }
   /**
-   * 특정 프리셋 PIN 넘버에 맞는 데이터를 반환하는 함수 getQuizPreset
+   * 특정 프리셋 PIN 넘버의 퀴즈 정답 목록을 반환하는 함수 getQuizAnswerList
    */
   static async getQuizAnswerList(req: Request, res: Response) {
     const { presetPin } = req.query;

--- a/src/controllers/quiz.controllers.ts
+++ b/src/controllers/quiz.controllers.ts
@@ -135,6 +135,7 @@ class QuizController {
       isPrivate = false,
       title,
       answers,
+      hints,
       hashtagContentList = [],
     } = req.body;
 
@@ -150,7 +151,8 @@ class QuizController {
     });
 
     await ServiceQuiz.registerQuizWithImage({
-      answers,
+      answers: Array.isArray(answers) ? answers : [answers],
+      hints : Array.isArray(hints) ? hints : [hints],
       imageFiles,
       presetPin,
     });

--- a/src/controllers/quiz.controllers.ts
+++ b/src/controllers/quiz.controllers.ts
@@ -163,6 +163,16 @@ class QuizController {
 
     return res.sendStatus(200);
   }
+
+  static async updateQuizPreset(req: Request, res: Response) {
+    const {
+      isPrivate = false,
+      title,
+      replacedQuizList = [],
+      hashtagContentList = [],
+    } = req.body;
+  }
+
 }
 
 export default QuizController;

--- a/src/docs/routes/quiz.yaml
+++ b/src/docs/routes/quiz.yaml
@@ -14,7 +14,13 @@ paths:
           required: true
           description: 퀴즈 프리셋 PIN
           schema:
-            type: string
+              type: string
+        - name: presetPin
+          in: query
+          required: true
+          description: 퀴즈 프리셋 PIN
+          schema:
+              type: string
       responses:
         '200':
           description: 퀴즈 프리셋 데이터 전송
@@ -51,6 +57,9 @@ paths:
                         answer:
                           type: string
                           description: 퀴즈 정답
+                        hint:
+                          type: string
+                          description: 퀴즈 힌트
         '400':
           description: 잘못된 요청 오류
           content:
@@ -112,6 +121,12 @@ paths:
                 answers:
                   required: true
                   description: 퀴즈 프리셋 내 퀴즈 정답 목록
+                  type: array
+                  items:
+                    type: string
+                hints:
+                  required: true
+                  description: 퀴즈 프리셋 내 퀴즈 힌트 목록
                   type: array
                   items:
                     type: string

--- a/src/models/quiz/model.ts
+++ b/src/models/quiz/model.ts
@@ -6,6 +6,7 @@ import { Schema, model } from 'mongoose';
 export interface QuizType {
   imageUrl: string;
   answer: string;
+  hint: string;
   includedPresetPin: string;
 }
 
@@ -13,6 +14,7 @@ export const Quiz = new Schema<QuizType>(
   {
     imageUrl: { type: String, required: true },
     answer: { type: String, required: true },
+    hint: { type: String },
     includedPresetPin: { type: String, required: true },
   },
   {

--- a/src/models/quiz/model.ts
+++ b/src/models/quiz/model.ts
@@ -6,7 +6,7 @@ import { Schema, model } from 'mongoose';
 export interface QuizType {
   imageUrl: string;
   answer: string;
-  hint: string;
+  hint?: string;
   includedPresetPin: string;
 }
 

--- a/src/models/quiz/quiz.ts
+++ b/src/models/quiz/quiz.ts
@@ -37,7 +37,7 @@ class ModelQuiz {
    */
   static async getQuizListInPreset(includedPresetPin: string) {
     const quizListInPreset = await model
-      .find({ includedPresetPin }, { imageUrl: 1, answer: 1, _id: 0 })
+      .find({ includedPresetPin }, { imageUrl: 1, answer: 1, hint: 1, _id: 0 })
       .sort({ createdAt: -1 })
       .lean()
       .exec();

--- a/src/models/quiz/quiz.ts
+++ b/src/models/quiz/quiz.ts
@@ -19,6 +19,7 @@ class ModelQuiz {
       imageUrl,
       answer,
       includedPresetPin,
+      hint,
     });
     return createdQuizPresetDocs;
   }
@@ -28,8 +29,17 @@ class ModelQuiz {
    * @param _id 업데이트 하고자 하는 퀴즈의 _id field
    * @param updatedPreset 업데이트 할 퀴즈의 정보
    */
-  static async updateQuizPreset(_id: string, updatedQuiz: Partial<QuizType>) {
+  static async updateQuizPreset(_id: string, updatedQuiz: Omit<Partial<QuizType>, '_id'>) {
     await model.updateOne({ _id }, { $set: { ...updatedQuiz } }).exec();
+  }
+
+  /**
+   * 기존의 퀴즈를 새롭게 덮어씌우는 함수 replaceQuizPreset
+   * @param _id 교체하고자 하는 퀴즈의 _id
+   * @param replacedQuiz 교체될 새로운 퀴즈의 정보
+   */
+  static async replaceQuizPreset(_id: string, replacedQuiz: QuizType) {
+    await model.replaceOne({ _id }, replacedQuiz);
   }
 
   /**

--- a/src/models/quiz/quiz.ts
+++ b/src/models/quiz/quiz.ts
@@ -13,6 +13,7 @@ class ModelQuiz {
     imageUrl,
     answer,
     includedPresetPin,
+    hint,
   }: QuizType) {
     const createdQuizPresetDocs = await model.create({
       imageUrl,

--- a/src/models/quizPreset/model.ts
+++ b/src/models/quizPreset/model.ts
@@ -6,19 +6,20 @@ import { Schema, model } from 'mongoose';
 export interface QuizPresetType {
   isPrivate: boolean;
   title: string;
+  presetPin: string,
 }
 
 /**
  * 퀴즈 프리셋 모델에 Pin 넘버 및 썸네일 Url이 포함된 타입
  */
-export type QuizPresetWithInfoType = QuizPresetType & {
-  presetPin: string;
+export type QuizPresetWithThumbnailType = QuizPresetType & {
   thumbnailUrl: string;
 };
 
 const QuizPreset = new Schema<QuizPresetType>(
   {
     isPrivate: { type: Boolean, required: true, default: false },
+    presetPin: { type: String, required: true },
     title: { type: String, required: true },
   },
   {

--- a/src/models/quizPreset/quizPreset.ts
+++ b/src/models/quizPreset/quizPreset.ts
@@ -1,6 +1,7 @@
 import { Types } from 'mongoose';
 
 import { BadRequestError } from '@/utils/definedErrors';
+import generatePin from '@/utils/generatePin';
 
 import model from './model';
 import type { QuizPresetType, QuizPresetWithInfoType } from './model';
@@ -164,6 +165,16 @@ class ModelQuizPreset {
     if (!result.deletedCount)
       throw new BadRequestError('요청하신 PIN 에 해당되는 프리셋이 없습니다');
   }
+
+  /**
+   * 새롭게 생성할 퀴즈 프리셋 PIN 번호를 생성하는 함수 generateQuizPresetPin
+   * @returns 새롭게 생성된 PIN 넘버
+   */
+  static async generateQuizPresetPin(): Promise<string> {
+    const generatedPin = generatePin();
+    const isExist = await ModelQuizPreset.getQuizPresetById(generatedPin);
+    return isExist ? await this.generateQuizPresetPin() : generatedPin;
+}
 }
 
 export default ModelQuizPreset;

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -8,15 +8,18 @@ class ServiceQuiz {
    * @param param.answers 퀴즈의 정답 목록
    * @param param.imageFiles 등록하고자 하는 퀴즈 이미지 Buffer
    * @param param.presetPin 등록하려는 퀴즈 프리셋 PIN
+   * @param param.hint 등록하려는 퀴즈 프리셋 힌트
    */
   static async registerQuizWithImage({
     answers,
     imageFiles,
     presetPin,
+    hint,
   }: {
     answers: string[];
     imageFiles: Express.Multer.File[];
     presetPin: string;
+    hint?: string;
   }) {
     await Promise.all(
       imageFiles.map(async (imageFile, index) => {
@@ -29,6 +32,7 @@ class ServiceQuiz {
           imageUrl,
           answer: currentIndexAnswer,
           includedPresetPin: presetPin,
+          hint,
         });
       }),
     );

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -8,18 +8,18 @@ class ServiceQuiz {
    * @param param.answers 퀴즈의 정답 목록
    * @param param.imageFiles 등록하고자 하는 퀴즈 이미지 Buffer
    * @param param.presetPin 등록하려는 퀴즈 프리셋 PIN
-   * @param param.hint 등록하려는 퀴즈 프리셋 힌트
+   * @param param.hints 등록하려는 퀴즈 프리셋 힌트
    */
   static async registerQuizWithImage({
     answers,
     imageFiles,
     presetPin,
-    hint,
+    hints,
   }: {
     answers: string[];
     imageFiles: Express.Multer.File[];
     presetPin: string;
-    hint?: string;
+    hints: (string | null)[];
   }) {
     await Promise.all(
       imageFiles.map(async (imageFile, index) => {
@@ -28,11 +28,12 @@ class ServiceQuiz {
           presetPin,
         });
         const currentIndexAnswer = answers[index];
+        const currentIndexHint = hints[index]
         await ModelQuiz.createQuizPreset({
           imageUrl,
           answer: currentIndexAnswer,
           includedPresetPin: presetPin,
-          hint,
+          hint: currentIndexHint ? currentIndexHint : undefined,
         });
       }),
     );

--- a/src/types/controllers/quizControllers.ts
+++ b/src/types/controllers/quizControllers.ts
@@ -1,5 +1,6 @@
 export type PostCreateQuizPresetReqBodyType = {
-  answers: string[];
+  answers: string[] | string;
+  hints: (string | null)[] | (string | null);
   title: string;
   isPrivate: boolean | undefined;
   hashtagContentList: string[];

--- a/src/types/controllers/quizControllers.ts
+++ b/src/types/controllers/quizControllers.ts
@@ -13,3 +13,7 @@ export type GetQuizPresetListReqQueryType = {
   page: number;
   limit: number;
 };
+
+export type GetQuizPresetReqQueryType = {
+  presetPin: string | string[];
+};

--- a/src/utils/generatePin.ts
+++ b/src/utils/generatePin.ts
@@ -1,0 +1,13 @@
+const generatePin = () => {
+    const charList = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    let generatedPin = '';
+
+    for (let index = 0; index < 6; index++) {
+        const randomIndex = Math.floor(Math.random() * charList.length);
+        generatedPin += charList[randomIndex];
+    }
+
+    return generatedPin;
+}
+
+export default generatePin;


### PR DESCRIPTION
## Github Issue 번호
#48

## 작업 내용
- 퀴즈 힌트 속성을 추가하고, 서버에서 이를 받아 처리하도록 로직을 수정하였습니다.
- 퀴즈가 1개만 등록되었을 때 정답이 한 글자만 짤려서 저장되었던 문제를 수정하였습니다.
- 프리셋 PIN을 query param에 여러 개 패싱했을 경우 각각의 데이터를 배열로 묶어 보내도록 했습니다.
- 기존의 `_id` 로 처리하였던 PIN 시스템을 영어 대문자 + 숫자 조합의 6글자 체제로 변경하였습니다.

## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
