### PR TITLE
[INT-46] 해시태그, 제목으로 퀴즈 프리셋을 검색하는 API 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "sharp": "0.32.1"
   },
   "devDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "4.1.1",
+    "@trivago/prettier-plugin-sort-imports": "4.2.0",
     "@types/cors": "2.8.13",
     "@types/dotenv": "8.2.0",
     "@types/express": "4.17.17",

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -150,12 +150,11 @@ class QuizController {
         return res.status(200).json(presetDataList);
       }
       case 'hashtag': {
-        const presetDataList =
-          await ServiceHashtag.getQuizPresetByHashtag({
-            content: keyword,
-            page: pageNum,
-            limit: limitNum,
-          });
+        const presetDataList = await ServiceHashtag.getQuizPresetByHashtag({
+          content: keyword,
+          page: pageNum,
+          limit: limitNum,
+        });
         return res.status(200).json(presetDataList);
       }
       default:

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -10,7 +10,7 @@ import {
   GetQuizPresetListReqQueryType,
   GetQuizPresetReqQueryType,
   PostCreateQuizPresetReqBodyType,
-} from '@/type/controllers/quizControllers';
+} from '@/types/controllers/quizControllers';
 import { BadRequestError } from '@/utils/definedErrors';
 
 class QuizController {

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -175,7 +175,7 @@ class QuizController {
       title,
       answers,
       hints,
-      hashtagContentList = [],
+      hashtagList = [],
     } = req.body;
 
     if (!title)
@@ -198,7 +198,7 @@ class QuizController {
 
     await ServiceHashtag.registerHashtagToPreset({
       presetPin,
-      hashtagContentList,
+      hashtagContentList: hashtagList,
     });
 
     return res.json({ presetPin });

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -151,7 +151,7 @@ class QuizController {
       }
       case 'hashtag': {
         const presetDataList =
-          await ServiceHashtag.getQuizPresetByHashtagContent({
+          await ServiceHashtag.getQuizPresetByHashtag({
             content: keyword,
             page: pageNum,
             limit: limitNum,

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -126,7 +126,7 @@ class QuizController {
     const { page = '1', limit = '9', keyword, type } = req.query;
     const [pageNum, limitNum] = [page, limit].map(Number);
 
-    if (typeof keyword !== 'string' || typeof type !== 'string' ) {
+    if (typeof keyword !== 'string' || typeof type !== 'string') {
       throw new BadRequestError(
         '퀴즈 프리셋 검색 타입 및 키워드를 요청에 추가해주세요.',
       );
@@ -143,7 +143,11 @@ class QuizController {
       }
       case 'hashtag': {
         const presetDataList =
-          await ServiceHashtag.getQuizPresetByHashtagContent(keyword);
+          await ServiceHashtag.getQuizPresetByHashtagContent({
+            content: keyword,
+            page: pageNum,
+            limit: limitNum,
+          });
         return res.status(200).json(presetDataList);
       }
       default:

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -132,6 +132,14 @@ class QuizController {
       );
     }
 
+    if (Number.isNaN(pageNum) || Number.isNaN(limitNum))
+      throw new BadRequestError(
+        'page 혹은 limit 값은 반드시 유효한 숫자여야 합니다.',
+      );
+
+    if (pageNum <= 0 || limitNum <= 0)
+      throw new BadRequestError('page 및 limit 값은 반드시 양수여야 합니다.');
+
     switch (type) {
       case 'title': {
         const presetDataList = await ModelQuizPreset.getQuizPresetByTitle({

--- a/src/controllers/test.json
+++ b/src/controllers/test.json
@@ -1,6 +1,0 @@
-{
-  "title": "",
-  "isPrivate": false,
-  "imageList": [],
-  "answerList": []
-}

--- a/src/docs/routes/quiz.yaml
+++ b/src/docs/routes/quiz.yaml
@@ -72,6 +72,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/quiz/search:
+    get:
+      summary: 제목 혹은 해시태그로 퀴즈 프리셋 목록 검색
+      tags:
+        - Quiz
+      parameters:
+        - name: type
+          in: query
+          required: true
+          description: 검색 타입
+          schema:
+              type: string
+              enum: [title, hashtag]
+        - name: keyword
+          in: query
+          required: true
+          description: 검색하고자 하는 키워드
+          schema:
+              type: string
+      responses:
+        '200':
+          description: 퀴즈 프리셋 데이터 전송
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                      description: 프리셋 제목
+                    isPrivate:
+                      type: boolean
+                      description: 프리셋 비공개 여부
+                    thumbnailUrl:
+                      type: string
+                      description: 프리셋 썸네일 이미지 URL
+                    presetPin:
+                      type: string
+                      description: 프리셋 PIN
+                    hashtagList:
+                      type: array
+                      description: 해시태그 목록
+                      items:
+                        type: string
+                    quizList:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          imageUrl:
+                            type: string
+                            description: 퀴즈 이미지 URL
+                          answer:
+                            type: string
+                            description: 퀴즈 정답
+                          hint:
+                            type: string
+                            description: 퀴즈 힌트
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/quiz/remove:
     delete:
       summary: 특정 PIN 에 해당되는 QuizPreset 삭제

--- a/src/models/hashtag/hashtag.ts
+++ b/src/models/hashtag/hashtag.ts
@@ -20,12 +20,7 @@ class ModelHashTag {
    */
   static async getHashtagContentById(hashtagId: string) {
     const hashtagContent = await model
-      .findOne(
-        {
-          _id: new Types.ObjectId(hashtagId),
-        },
-        { content: 1, _id: 0 },
-      )
+      .findById(hashtagId, { content: 1, _id: 0 })
       .lean()
       .exec();
     return hashtagContent?.content ?? null;
@@ -33,7 +28,7 @@ class ModelHashTag {
 
   /**
    * 컨텐츠를 기반으로 해시태그 ID를 가져오는 함수 getHashtagIdByContent
-   * @param hashtagId 해시태그 ID
+   * @param content 해시태그 컨텐츠
    */
   static async getHashtagIdByContent(content: string) {
     const hashtagId = await model

--- a/src/models/hashtag/hashtag.ts
+++ b/src/models/hashtag/hashtag.ts
@@ -1,5 +1,3 @@
-import { Types } from 'mongoose';
-
 import model from './model';
 
 class ModelHashTag {

--- a/src/models/quizPreset/quizPreset.ts
+++ b/src/models/quizPreset/quizPreset.ts
@@ -1,5 +1,6 @@
 import { Types } from 'mongoose';
 
+import { type PaginatedType } from '@/types/util';
 import { BadRequestError } from '@/utils/definedErrors';
 import generatePin from '@/utils/generatePin';
 
@@ -43,7 +44,7 @@ class ModelQuizPreset {
    * @param param.page 불러올 페이지
    * @param param.limit 한 페이지 당 불러올 document 수량
    */
-  static async getQuizPreset({ page, limit }: { page: number; limit: number }) {
+  static async getQuizPreset({ page, limit }: PaginatedType) {
     const quizPresetList = await model
       .aggregate<QuizPresetWithThumbnailType>([
         {
@@ -160,11 +161,7 @@ class ModelQuizPreset {
     title,
     page,
     limit,
-  }: {
-    title: string;
-    page: number;
-    limit: number;
-  }) {
+  }: PaginatedType<Pick<QuizPresetType, 'title'>>) {
     const quizPresetList = await model.aggregate<QuizPresetWithThumbnailType>([
       {
         $match: { title: { $regex: title, $options: 'i' } },

--- a/src/models/quizPresetHashtag/quizPresetHashtag.ts
+++ b/src/models/quizPresetHashtag/quizPresetHashtag.ts
@@ -1,3 +1,5 @@
+import { PaginatedType } from '@/types/util';
+
 import model from './model';
 import type { QuizPresetHashtagType } from './model';
 
@@ -35,18 +37,23 @@ class ModelQuizPresetHashtag {
 
   /**
    * 특정 해시태그 ID 를 포함한 퀴즈 프리셋 목록을 가져오는 함수 getPresetListByHashtagId
-   * @param hashtagId 해시태그 ID 
+   * @param hashtagId 해시태그 ID
    */
-    static async getPresetListByHashtagId(hashtagId: string) {
-      const queryResult = await model
-        .find({ hashtagId }, { presetPin: 1, _id: 0 })
-        .lean()
-        .exec();
-  
-      const presetPinList = queryResult.map(({ presetPin }) => presetPin);
-      return presetPinList;
-    }
-  
+  static async getPresetListByHashtagId({
+    hashtagId,
+    page,
+    limit,
+  }: PaginatedType<Pick<QuizPresetHashtagType, 'hashtagId'>>) {
+    const queryResult = await model
+      .find({ hashtagId }, { presetPin: 1, _id: 0 })
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .lean()
+      .exec();
+
+    const presetPinList = queryResult.map(({ presetPin }) => presetPin);
+    return presetPinList;
+  }
 
   /**
    * 프리셋에 등록되었던 해시태그를 삭제하는 함수 deleteHashtagIdsFromPreset

--- a/src/models/quizPresetHashtag/quizPresetHashtag.ts
+++ b/src/models/quizPresetHashtag/quizPresetHashtag.ts
@@ -34,6 +34,21 @@ class ModelQuizPresetHashtag {
   }
 
   /**
+   * 특정 해시태그 ID 를 포함한 퀴즈 프리셋 목록을 가져오는 함수 getPresetListByHashtagId
+   * @param hashtagId 해시태그 ID 
+   */
+    static async getPresetListByHashtagId(hashtagId: string) {
+      const queryResult = await model
+        .find({ hashtagId }, { presetPin: 1, _id: 0 })
+        .lean()
+        .exec();
+  
+      const presetPinList = queryResult.map(({ presetPin }) => presetPin);
+      return presetPinList;
+    }
+  
+
+  /**
    * 프리셋에 등록되었던 해시태그를 삭제하는 함수 deleteHashtagIdsFromPreset
    * @param param.hashtagId 프리셋에서 삭제하려는 Hashtag Id
    * @param param.presetPin 해시태그를 수정하려는 프리셋 PIN

--- a/src/routes/quiz.router.ts
+++ b/src/routes/quiz.router.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import QuizController from '@/controllers/quiz.controllers';
+import QuizController from '@/controllers/quiz.controller';
 import upload from '@/middlewares/multer';
 import midResizeImage from '@/middlewares/resizeImage';
 import { errorCatchHandler } from '@/utils/errorCatchHandler';
@@ -10,6 +10,10 @@ const quizRouter = express.Router();
 quizRouter.get('/', errorCatchHandler(QuizController.getQuizPreset));
 quizRouter.get('/list', errorCatchHandler(QuizController.getQuizPresetList));
 quizRouter.get('/answer', errorCatchHandler(QuizController.getQuizAnswerList));
+quizRouter.get(
+  '/search',
+  errorCatchHandler(QuizController.getQuizPresetListBySearch),
+);
 
 quizRouter.delete(
   '/remove',

--- a/src/services/hashtag.service.ts
+++ b/src/services/hashtag.service.ts
@@ -1,7 +1,9 @@
+import { HashtagType } from '@/models/hashtag';
 import ModelHashTag from '@/models/hashtag/hashtag';
 import { type QuizPresetWithThumbnailType } from '@/models/quizPreset';
 import ModelQuizPreset from '@/models/quizPreset/quizPreset';
 import ModelQuizPresetHashtag from '@/models/quizPresetHashtag/quizPresetHashtag';
+import { PaginatedType } from '@/types/util';
 
 class ServiceHashtag {
   /**
@@ -68,15 +70,21 @@ class ServiceHashtag {
     );
   }
 
-  static async getQuizPresetByHashtagContent(hashtagContent: string) {
-    const hashtagId = await ModelHashTag.getHashtagIdByContent(
-      hashtagContent,
-    );
+  static async getQuizPresetByHashtagContent({
+    content,
+    page,
+    limit,
+  }: PaginatedType<Pick<HashtagType, 'content'>>) {
+    const hashtagId = await ModelHashTag.getHashtagIdByContent(content);
 
     if (!hashtagId) return [];
 
     const presetPinList = await ModelQuizPresetHashtag.getPresetListByHashtagId(
-      hashtagId,
+      {
+        hashtagId,
+        page,
+        limit,
+      },
     );
 
     const presetDataList: QuizPresetWithThumbnailType[] = await Promise.all(

--- a/src/services/hashtag.service.ts
+++ b/src/services/hashtag.service.ts
@@ -1,4 +1,6 @@
 import ModelHashTag from '@/models/hashtag/hashtag';
+import { type QuizPresetWithThumbnailType } from '@/models/quizPreset';
+import ModelQuizPreset from '@/models/quizPreset/quizPreset';
 import ModelQuizPresetHashtag from '@/models/quizPresetHashtag/quizPresetHashtag';
 
 class ServiceHashtag {
@@ -11,9 +13,9 @@ class ServiceHashtag {
       presetPin,
     );
     const hashtagList = await Promise.all(
-      hashtagIdList.map((hashtagId) => {
-        return ModelHashTag.getHashtagContentById(hashtagId);
-      }),
+      hashtagIdList.map((hashtagId) =>
+        ModelHashTag.getHashtagContentById(hashtagId),
+      ),
     );
     return hashtagList;
   }
@@ -64,6 +66,26 @@ class ServiceHashtag {
         }),
       ),
     );
+  }
+
+  static async getQuizPresetByHashtagContent(hashtagContent: string) {
+    const hashtagId = await ModelHashTag.getHashtagIdByContent(
+      hashtagContent,
+    );
+
+    if (!hashtagId) return [];
+
+    const presetPinList = await ModelQuizPresetHashtag.getPresetListByHashtagId(
+      hashtagId,
+    );
+
+    const presetDataList: QuizPresetWithThumbnailType[] = await Promise.all(
+      presetPinList.map((presetPin) =>
+        ModelQuizPreset.getQuizPresetById(presetPin),
+      ),
+    );
+
+    return presetDataList;
   }
 }
 

--- a/src/services/hashtag.service.ts
+++ b/src/services/hashtag.service.ts
@@ -2,7 +2,7 @@ import { HashtagType } from '@/models/hashtag';
 import ModelHashTag from '@/models/hashtag/hashtag';
 import ModelQuizPreset from '@/models/quizPreset/quizPreset';
 import ModelQuizPresetHashtag from '@/models/quizPresetHashtag/quizPresetHashtag';
-import { PaginatedType } from '@/types/util';
+import { type PaginatedType } from '@/types/util';
 
 class ServiceHashtag {
   /**

--- a/src/services/hashtag.service.ts
+++ b/src/services/hashtag.service.ts
@@ -1,6 +1,5 @@
 import { HashtagType } from '@/models/hashtag';
 import ModelHashTag from '@/models/hashtag/hashtag';
-import { type QuizPresetWithThumbnailType } from '@/models/quizPreset';
 import ModelQuizPreset from '@/models/quizPreset/quizPreset';
 import ModelQuizPresetHashtag from '@/models/quizPresetHashtag/quizPresetHashtag';
 import { PaginatedType } from '@/types/util';
@@ -70,7 +69,7 @@ class ServiceHashtag {
     );
   }
 
-  static async getQuizPresetByHashtagContent({
+  static async getQuizPresetByHashtag({
     content,
     page,
     limit,
@@ -87,7 +86,7 @@ class ServiceHashtag {
       },
     );
 
-    const presetDataList: QuizPresetWithThumbnailType[] = await Promise.all(
+    const presetDataList = await Promise.all(
       presetPinList.map((presetPin) =>
         ModelQuizPreset.getQuizPresetById(presetPin),
       ),

--- a/src/types/controllers/quizControllers.ts
+++ b/src/types/controllers/quizControllers.ts
@@ -3,7 +3,7 @@ export type PostCreateQuizPresetReqBodyType = {
   hints: (string | null)[] | (string | null);
   title: string;
   isPrivate: boolean | undefined;
-  hashtagContentList: string[];
+  hashtagList: string[];
 };
 
 export type DeleteQuizPresetReqQueryType = {

--- a/src/types/controllers/quizControllers.ts
+++ b/src/types/controllers/quizControllers.ts
@@ -18,3 +18,10 @@ export type GetQuizPresetListReqQueryType = {
 export type GetQuizPresetReqQueryType = {
   presetPin: string | string[];
 };
+
+export type GetQuizPresetBySearchReqQueryType = {
+  type: 'title' | 'hashtag';
+  keyword: string;
+  page: number;
+  limit: number;
+}

--- a/src/types/controllers/quizControllers.ts
+++ b/src/types/controllers/quizControllers.ts
@@ -1,3 +1,5 @@
+import { type PaginatedType } from '../util';
+
 export type PostCreateQuizPresetReqBodyType = {
   answers: string[] | string;
   hints: (string | null)[] | (string | null);
@@ -10,18 +12,13 @@ export type DeleteQuizPresetReqQueryType = {
   presetPin: string | undefined;
 };
 
-export type GetQuizPresetListReqQueryType = {
-  page: number;
-  limit: number;
-};
+export type GetQuizPresetListReqQueryType = PaginatedType;
 
 export type GetQuizPresetReqQueryType = {
   presetPin: string | string[];
 };
 
-export type GetQuizPresetBySearchReqQueryType = {
+export type GetQuizPresetBySearchReqQueryType = PaginatedType<{
   type: 'title' | 'hashtag';
   keyword: string;
-  page: number;
-  limit: number;
-}
+}>;

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,1 +1,1 @@
-export type PaginatedType<T = unknown> = { page: number, limit: number } & T;
+export type PaginatedType<T = unknown> = { page: number; limit: number } & T;

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,0 +1,1 @@
+export type PaginatedType<T = unknown> = { page: number, limit: number } & T;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "@/services/*": ["src/services/*"],
       "@/utils/*": ["src/utils/*"],
       "@/validations/*": ["src/validations/*"],
-      "@/type/*": ["src/types/*"]
+      "@/types/*": ["src/types/*"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trivago/prettier-plugin-sort-imports@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz#71c3c1ae770c3738b6fc85710714844477574ffd"
-  integrity sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==
+"@trivago/prettier-plugin-sort-imports@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.2.0.tgz#b240366f9e2bda8e14edb18b14ea084e0ec25968"
+  integrity sha512-YBepjbt+ZNBVmN3ev1amQH3lWCmHyt5qTbLCp/syXJRu/Kw2koXh44qayB1gMRxcL/gV8egmjN5xWSrYyfUtyw==
   dependencies:
     "@babel/generator" "7.17.7"
     "@babel/parser" "^7.20.5"


### PR DESCRIPTION
## Github Issue 번호
#46

## 작업 내용
- 해시태그, 제목으로 퀴즈 프리셋 목록을 페이지네이션으로 조회하는 API를 제작하였습니다.
- PaginatedType 유틸 타입을 신설하고, 페이지네이션 관련 로직을 해당 유틸 타입으로 수정하였습니다.
- page, limit 관련 query param 값이 유효하지 않은 경우에 대한 Validation 로직을 추가하였습니다.

## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
